### PR TITLE
feat: expand signal detection patterns

### DIFF
--- a/services/signal_parser.py
+++ b/services/signal_parser.py
@@ -15,12 +15,16 @@ class SignalType:
 SIGNAL_PATTERNS = [
     {
         "type": SignalType.CANCELAR,
-        "pattern": re.compile(r'⚠️\s*(\w+)\s*Sinal\s*Cancelado', re.IGNORECASE),
+        # Aceita variações como "⚠️ BTC - Sinal Cancelado" ou "⚠️ BTC Sinal Cancelada"
+        "pattern": re.compile(r'⚠️\s*(\w+)[^\n]*sinal\s*cancelad[oa]', re.IGNORECASE),
         "extractor": lambda m: {"coin": m.group(1)}
     },
     {
         "type": "FULL_SIGNAL", # Padrão para sinais completos (Ordem Limite ou a Mercado)
-        "pattern": re.compile(r'(?=.*Moeda:)(?=.*Tipo:)(?=.*Stop Loss:)', re.IGNORECASE | re.DOTALL),
+        "pattern": re.compile(
+            r'(?=.*(?:Moeda|Coin|Pair):)(?=.*Tipo:)(?=.*Stop\s*Loss:)',
+            re.IGNORECASE | re.DOTALL,
+        ),
         "extractor": "full_signal_extractor"
     }
 ]
@@ -44,7 +48,7 @@ def _full_signal_extractor(message_text: str) -> Optional[Dict[str, Any]]:
     elif 'ordem à mercado' in text_lower or 'sinal entrou no preço' in text_lower:
         signal_type = SignalType.MARKET
 
-    coin = find_single_value(r'💎\s*Moeda:\s*(\w+)', message_text)
+    coin = find_single_value(r'(?:💎\s*)?(?:Moeda|Coin|Pair):\s*(\w+)', message_text)
     order_type = find_single_value(r'Tipo:\s*(LONG|SHORT)', message_text)
     entry_zone_str = find_single_value(r'Zona\s*de\s*Entrada:\s*([\d\.\,\s-]+)', message_text)
     stop_loss_str = find_single_value(r'Stop\s*Loss:\s*([\d\.\,]+)', message_text)

--- a/services/telethon_service.py
+++ b/services/telethon_service.py
@@ -78,7 +78,12 @@ async def list_channel_topics(channel_id: int):
     return topics
 
 # --- Listener de Sinais ---
-SIGNAL_PATTERN = re.compile(r'💎\s*Moeda:', re.IGNORECASE)
+# Captura tanto mensagens de novos sinais quanto cancelamentos,
+# aceitando variações sem o emoji 💎 e sinônimos para "Moeda"
+SIGNAL_PATTERN = re.compile(
+    r'((?:💎\s*)?(?:Moeda|Coin|Pair):|Tipo:|Zona\s*de\s*Entrada:|Stop\s*Loss:|Sinal\s*Cancelad[oa])',
+    re.IGNORECASE,
+)
 
 @client.on(events.NewMessage(pattern=SIGNAL_PATTERN))
 @client.on(events.MessageEdited(pattern=SIGNAL_PATTERN))

--- a/tests/test_signal_parser.py
+++ b/tests/test_signal_parser.py
@@ -1,0 +1,41 @@
+import textwrap
+
+from services.signal_parser import parse_signal, SignalType
+
+
+def test_parse_signal_without_diamond():
+    message = textwrap.dedent(
+        """
+        ⏳ #1 - Ordem Limite
+        Moeda: SOL
+        Tipo: SHORT (Futures)
+        Zona de Entrada: 182.66 - 182.66
+        Stop Loss: 186.36
+        Alvos:
+        T1: 181.18
+        """
+    )
+
+    data = parse_signal(message)
+
+    assert data["coin"] == "SOLUSDT"
+    assert data["type"] == SignalType.LIMIT
+
+
+def test_parse_signal_with_coin_synonym():
+    message = textwrap.dedent(
+        """
+        ⏳ #2 - Ordem Limite
+        Coin: NMR
+        Tipo: SHORT (Futures)
+        Zona de Entrada: 8.04 - 8.28
+        Stop Loss: 8.55
+        Alvos:
+        T1: 7.99
+        """
+    )
+
+    data = parse_signal(message)
+
+    assert data["coin"] == "NMRUSDT"
+    assert data["type"] == SignalType.LIMIT


### PR DESCRIPTION
## Summary
- allow signal parsing without 💎 marker and accept Coin/Pair synonyms
- detect signals when key fields like Tipo or Stop Loss appear
- add parser tests for messages without emoji or with Coin label

## Testing
- ⚠️ `pip install flake8` (proxy error: Tunnel connection failed: 403 Forbidden)
- ⚠️ `flake8 services/signal_parser.py services/telethon_service.py` (command not found)
- ✅ `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a73dc15f8c832eaa32f2e839e79e1e