### PR TITLE
fix: parse market signals without accent

### DIFF
--- a/services/signal_parser.py
+++ b/services/signal_parser.py
@@ -1,5 +1,6 @@
 import re
 import logging
+import unicodedata
 from typing import Dict, Any, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -44,11 +45,15 @@ def _full_signal_extractor(message_text: str) -> Optional[Dict[str, Any]]:
         matches = re.findall(pattern, text, re.IGNORECASE | re.MULTILINE)
         return [float(v.replace(',', '.')) for v in matches]
 
-    text_lower = message_text.lower()
+    def normalize_text(text: str) -> str:
+        """Remove acentos e converte para minúsculas."""
+        return unicodedata.normalize("NFKD", text).encode("ASCII", "ignore").decode("utf-8").lower()
+
+    text_normalized = normalize_text(message_text)
     signal_type = None
-    if 'ordem limite' in text_lower:
+    if 'ordem limite' in text_normalized:
         signal_type = SignalType.LIMIT
-    elif 'ordem à mercado' in text_lower or 'sinal entrou no preço' in text_lower:
+    elif 'ordem a mercado' in text_normalized or 'sinal entrou no preco' in text_normalized:
         signal_type = SignalType.MARKET
 
     # Regex atualizadas para serem mais tolerantes, buscando do início da linha (^)

--- a/tests/test_signal_parser.py
+++ b/tests/test_signal_parser.py
@@ -88,3 +88,22 @@ def test_parse_complex_signal_with_emojis_and_extra_text():
     assert data["stop_loss"] == 2.9
     assert data["targets"] == [2.44, 2.37, 2.29, 2.2]
     assert data["confidence"] == 66.67
+
+
+def test_parse_market_signal_without_accent():
+    message = textwrap.dedent(
+        """
+        🏁 #123 - Ordem a Mercado
+        Moeda: AVAX
+        Tipo: SHORT (Futures)
+        Zona de Entrada: 22.85 - 22.85
+        Stop Loss: 24.22
+        Alvos:
+        T1: 22.69
+        """
+    )
+
+    data = parse_signal(message)
+
+    assert data["type"] == SignalType.MARKET
+    assert data["coin"] == "AVAXUSDT"


### PR DESCRIPTION
## Summary
- handle order type parsing without accented letters
- cover market signal without accent in parser tests

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7c070c8dc832e959f7ecb8ebf2142